### PR TITLE
Set strong parameter for sign_up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,16 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def after_sign_in_path_for(resource)
+      users_path
+  end
+
+  private
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :family_name, :first_name, :family_name_phonetic, :first_name_phonetic, :birth_year, :birth_month, :birth_day])
+  end
+  def sign_in_required
+      redirect_to new_user_session_url unless user_signed_in?
+  end
 end


### PR DESCRIPTION
# Whaat
メールアドレスを利用したログイン用にdeviseのパラメーター取得の設定を変更した。

# Why
デフォルトであるdeviseのストロングパラメーター設定を変更しないとDBに必要なカラムのデータを渡せないため。